### PR TITLE
Reorganize themes, add careers-site initiative

### DIFF
--- a/data/initiatives.yml
+++ b/data/initiatives.yml
@@ -11,14 +11,13 @@ worker-runner-everywhere:
   title: Use worker-runner everywhere
   themes:
     - usability
-    - operations
   description: >-
     [more information](https://bugzilla.mozilla.org/show_bug.cgi?id=1602946)
 
 service-deployment-streamlined:
   title: Streamline service deployment configuration
   themes:
-    - operations
+    - usability
     - tc-adoption
   description: >-
     [more information](https://github.com/taskcluster/taskcluster/projects/8)
@@ -138,3 +137,11 @@ automated-worker-image-builds:
     mozilla/community-tc-config, so that it is no longer necessary for humans
     to trigger machine builds manually, or modify machine image references in
     Worker Manager worker pool definitions.
+
+careers-website:
+  title: Bring careers website up to standards, into bedrock
+  themes:
+    - maintenance
+  description: >-
+    Address some long-standing issues with the careers website and work to
+    integrate it into the bedrock system so that it remains up-to-date.

--- a/data/themes.yml
+++ b/data/themes.yml
@@ -8,29 +8,38 @@
 actionable-data:
   title: Make data actionable
   description: >-
-    TBD
+    Provide data to project stakeholders that can be used to make decisions
+    about the project.
 
 tc-adoption:
-  title: Promote external adoption
+  title: Promote Taskcluster's external adoption
   description: >-
     Promote adoption and use of Taskcluster more broadly than Firefox CI
 
 usability:
-  title: Improve usability
+  title: Improve Taskcluster usability
   description: >-
     Improve Taskcluster's usability and suitability for common uses.  This
     includes both quality-of-life improvements and substantial features to
-    support users' needs.
+    support users' needs.  This includes support for deployment and operation
+    of Taskcluster (configuration, logging, monitoring, etc.)
 
 cost-reduction:
   title: Support cost reduction
   description: >-
-    Build functionality that can be used to reduce CI costs
+    Build functionality that can be used to reduce costs for the projects we
+    develop and operate.
+
+maintenance:
+  title: Project Maintenance
+  description: >-
+    Ongoing maintenance of Mozilla software projects, with specific goals in
+    mind for each project, such as continued operation, retirement, or handoff
+    to another team (internal or external).
 
 operations:
-  title: More efficient, reliable operations
+  title: Team Operations
   description: >-
     Improve our operational efficiency, including
      * Management of Community-TC
-     * Support for deployment and operation of Taskcluster (configuration, logging, monitoring, etc.)
      * General team operations (secret handling, access control, etc.)

--- a/gen/initiatives.md
+++ b/gen/initiatives.md
@@ -6,6 +6,7 @@ The following are the current initiatives:
 
 * [Artifact Integrity](#artifact-integrity)
 * [Automatic rebuilding of worker machine images](#automated-worker-image-builds)
+* [Bring careers website up to standards, into bedrock](#careers-website)
 * [Implement the Github Checks API](#checks-api)
 * [Automatically deploy config changes to community-tc](#community-tc-deployment)
 * [Move frequently-updated complex configuration out of the deployment config and into the API](#config-in-api)
@@ -33,7 +34,7 @@ To update this information, edit `data/initiatives.yml` and run `generate.py`.
 
 *Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## automated-worker-image-builds
@@ -54,8 +55,20 @@ This initiative is about enabling the automatic build of cloud machine images wh
 
 *Addresses Themes:*
 
-* [More efficient, reliable operations](./themes.md#operations)
+* [Team Operations](./themes.md#operations)
 * [Support cost reduction](./themes.md#cost-reduction)
+
+
+## careers-website
+*Bring careers website up to standards, into bedrock*
+
+Address some long-standing issues with the careers website and work to integrate it into the bedrock system so that it remains up-to-date.
+
+[*Associated Epics*](https://github.com/taskcluster/scrum/issues?q=is%3Aissue+is%3Aopen+label%3Ainitiative%3Acareers-website)
+
+*Addresses Theme:*
+
+* [Project Maintenance](./themes.md#maintenance)
 
 
 ## checks-api
@@ -67,8 +80,8 @@ This initiative is about enabling the automatic build of cloud machine images wh
 
 *Addresses Themes:*
 
-* [Improve usability](./themes.md#usability)
-* [Promote external adoption](./themes.md#tc-adoption)
+* [Improve Taskcluster usability](./themes.md#usability)
+* [Promote Taskcluster's external adoption](./themes.md#tc-adoption)
 
 
 ## community-tc-deployment
@@ -80,7 +93,7 @@ TBD
 
 *Addresses Theme:*
 
-* [More efficient, reliable operations](./themes.md#operations)
+* [Team Operations](./themes.md#operations)
 
 
 ## config-in-api
@@ -92,7 +105,7 @@ TBD
 
 *Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## decom-docker-worker
@@ -104,7 +117,7 @@ TBD
 
 *Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## object-service
@@ -117,7 +130,7 @@ TBD
 *Addresses Themes:*
 
 * [Support cost reduction](./themes.md#cost-reduction)
-* [Promote external adoption](./themes.md#tc-adoption)
+* [Promote Taskcluster's external adoption](./themes.md#tc-adoption)
 * [Make data actionable](./themes.md#actionable-data)
 
 
@@ -130,7 +143,7 @@ Support deployments of Taskcluster which do not provide open access to read-only
 
 *Addresses Theme:*
 
-* [Promote external adoption](./themes.md#tc-adoption)
+* [Promote Taskcluster's external adoption](./themes.md#tc-adoption)
 
 
 ## project-id
@@ -142,7 +155,7 @@ Support deployments of Taskcluster which do not provide open access to read-only
 
 *Addresses Themes:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 * [Make data actionable](./themes.md#actionable-data)
 
 
@@ -155,7 +168,7 @@ Support deployments of Taskcluster which do not provide open access to read-only
 
 *Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## service-deployment-streamlined
@@ -167,8 +180,8 @@ Support deployments of Taskcluster which do not provide open access to read-only
 
 *Addresses Themes:*
 
-* [More efficient, reliable operations](./themes.md#operations)
-* [Promote external adoption](./themes.md#tc-adoption)
+* [Improve Taskcluster usability](./themes.md#usability)
+* [Promote Taskcluster's external adoption](./themes.md#tc-adoption)
 
 
 ## task-queue-id
@@ -180,7 +193,7 @@ Support deployments of Taskcluster which do not provide open access to read-only
 
 *Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## taskcluster-yml-helper
@@ -192,8 +205,8 @@ TBD
 
 *Addresses Themes:*
 
-* [Improve usability](./themes.md#usability)
-* [Promote external adoption](./themes.md#tc-adoption)
+* [Improve Taskcluster usability](./themes.md#usability)
+* [Promote Taskcluster's external adoption](./themes.md#tc-adoption)
 
 
 ## use-sops
@@ -205,7 +218,7 @@ TBD
 
 *Addresses Theme:*
 
-* [More efficient, reliable operations](./themes.md#operations)
+* [Team Operations](./themes.md#operations)
 
 
 ## worker-capacity-estimates
@@ -227,10 +240,9 @@ TBD
 
 [*Associated Epics*](https://github.com/taskcluster/scrum/issues?q=is%3Aissue+is%3Aopen+label%3Ainitiative%3Aworker-runner-everywhere)
 
-*Addresses Themes:*
+*Addresses Theme:*
 
-* [Improve usability](./themes.md#usability)
-* [More efficient, reliable operations](./themes.md#operations)
+* [Improve Taskcluster usability](./themes.md#usability)
 
 
 ## worker-structured-logging

--- a/gen/themes.md
+++ b/gen/themes.md
@@ -6,16 +6,17 @@ The following are the current themes:
 
 * [Make data actionable](#actionable-data)
 * [Support cost reduction](#cost-reduction)
-* [More efficient, reliable operations](#operations)
-* [Promote external adoption](#tc-adoption)
-* [Improve usability](#usability)
+* [Project Maintenance](#maintenance)
+* [Team Operations](#operations)
+* [Promote Taskcluster's external adoption](#tc-adoption)
+* [Improve Taskcluster usability](#usability)
 
 To update this information, edit `data/themes.yml` and run `generate.py`.
 
 ## actionable-data
 *Make data actionable*
 
-TBD
+Provide data to project stakeholders that can be used to make decisions about the project.
 
 *Associated Initiatives:*
 
@@ -27,7 +28,7 @@ TBD
 ## cost-reduction
 *Support cost reduction*
 
-Build functionality that can be used to reduce CI costs
+Build functionality that can be used to reduce costs for the projects we develop and operate.
 
 *Associated Initiatives:*
 
@@ -36,25 +37,32 @@ Build functionality that can be used to reduce CI costs
 * [Automatic rebuilding of worker machine images](./initiatives.md#automated-worker-image-builds)
 
 
+## maintenance
+*Project Maintenance*
+
+Ongoing maintenance of Mozilla software projects, with specific goals in mind for each project, such as continued operation, retirement, or handoff to another team (internal or external).
+
+*Associated Initiatives:*
+
+* [Bring careers website up to standards, into bedrock](./initiatives.md#careers-website)
+
+
 ## operations
-*More efficient, reliable operations*
+*Team Operations*
 
 Improve our operational efficiency, including
  * Management of Community-TC
- * Support for deployment and operation of Taskcluster (configuration, logging, monitoring, etc.)
  * General team operations (secret handling, access control, etc.)
 
 *Associated Initiatives:*
 
-* [Use worker-runner everywhere](./initiatives.md#worker-runner-everywhere)
-* [Streamline service deployment configuration](./initiatives.md#service-deployment-streamlined)
 * [Use SOPS instead of password-store](./initiatives.md#use-sops)
 * [Automatically deploy config changes to community-tc](./initiatives.md#community-tc-deployment)
 * [Automatic rebuilding of worker machine images](./initiatives.md#automated-worker-image-builds)
 
 
 ## tc-adoption
-*Promote external adoption*
+*Promote Taskcluster's external adoption*
 
 Promote adoption and use of Taskcluster more broadly than Firefox CI
 
@@ -68,13 +76,14 @@ Promote adoption and use of Taskcluster more broadly than Firefox CI
 
 
 ## usability
-*Improve usability*
+*Improve Taskcluster usability*
 
-Improve Taskcluster's usability and suitability for common uses.  This includes both quality-of-life improvements and substantial features to support users' needs.
+Improve Taskcluster's usability and suitability for common uses.  This includes both quality-of-life improvements and substantial features to support users' needs.  This includes support for deployment and operation of Taskcluster (configuration, logging, monitoring, etc.)
 
 *Associated Initiatives:*
 
 * [Use worker-runner everywhere](./initiatives.md#worker-runner-everywhere)
+* [Streamline service deployment configuration](./initiatives.md#service-deployment-streamlined)
 * [Implement projectId](./initiatives.md#project-id)
 * [Implement taskQueueId](./initiatives.md#task-queue-id)
 * [Implement the Github Checks API](./initiatives.md#checks-api)


### PR DESCRIPTION
This reorganizes the themes for the team to recognize that we maintain a
few projects now that are not Taskcluster (MLS, Pulseguardian, Careers),
and operate a bit of those too.  Some of the themes remain TC-specific,
but some (data and costs) are more general.  Note that I moved work on
making Taskcluster more operations-friendly into the `usability` theme.

This also adds a new "careers-website" initiative to track work on that
website.

@helfi92 / @ccooper please revise my language about careers if necessary.